### PR TITLE
fix/delete a list by owner id

### DIFF
--- a/server/src/repositories/lists.ts
+++ b/server/src/repositories/lists.ts
@@ -127,7 +127,7 @@ export default class ListsRepositories {
                 throw ErrorHandler.createError("BadRequest", "List not found");
             }
 
-            if (list.owner !== ownerId) {
+            if (list.owner.toString() !== ownerId) {
                 throw ErrorHandler.createError(
                     "UnauthorizedError",
                     "forbiddenError"


### PR DESCRIPTION
fixing a bug in the delete list
I fixed it yesterday but I think when it came time to resolve the conflicts it was deleted haha.
test:
http://localhost:{PORT}/api/lists/:listid
it is only possible to delete a list if the user owns it