### PR TITLE
feat: make price optional

### DIFF
--- a/client/src/components/CheckboxList.tsx
+++ b/client/src/components/CheckboxList.tsx
@@ -80,6 +80,8 @@ function CheckboxListItem(props: CheckboxListItemProps) {
             inputProps={{ "aria-labelledby": props.labelId }}
           />
         </ListItemIcon>
+        {/* Aqui está um comentário para quem for fazer esse componente:
+            O PREÇO DEVE SER ESCONDIDO CASO SEJA ZERO REAIS */}
         <ListItemText
           sx={{
             textDecoration: props.item.checked ? "line-through" : "none",
@@ -87,9 +89,7 @@ function CheckboxListItem(props: CheckboxListItemProps) {
           id={props.labelId}
           primary={`${props.item.name} ${props.item.quantity} ${
             props.item.unit
-          } R$${(props.item.price * props.item.quantity)
-            .toFixed(2)
-            .replace(".", ",")}`}
+          } R$${props.item.price.toFixed(2).replace(".", ",")}`}
         />
       </ListItemButton>
     </ListItem>

--- a/client/src/views/list/ListPage.tsx
+++ b/client/src/views/list/ListPage.tsx
@@ -200,7 +200,8 @@ export default function List() {
           name: formData["name"],
           quantity: formData["quantity"],
           unit: formData["unit"],
-          price: formData["price"],
+          price: formData["price"] === "" ? 0 : formData["price"],
+          market: formData["market"],
           checked: false,
         }),
       });
@@ -313,7 +314,8 @@ export default function List() {
             name: formData["name"],
             quantity: formData["quantity"],
             unit: formData["unit"],
-            price: formData["price"],
+            price: formData["price"] === "" ? 0 : formData["price"],
+            market: formData["market"],
           }),
         }
       );
@@ -426,6 +428,7 @@ export default function List() {
           { id: "unit", label: "Unidade de medida", type: "select" },
           { id: "quantity", label: "Quantidade", type: "text" },
           { id: "price", label: "Preço/unidade", type: "text" },
+          { id: "market", label: "Local da compra", type: "text" },
         ]}
         open={openItemForm}
         handleClose={handleCloseItemForm}
@@ -453,6 +456,7 @@ export default function List() {
           { id: "unit", label: "Unidade de medida", type: "text" },
           { id: "quantity", label: "Quantidade", type: "text" },
           { id: "price", label: "Preço/unidade", type: "text" },
+          { id: "market", label: "Local da compra", type: "text" },
         ]}
         open={openEditItemForm}
         handleClose={handleCloseEditItemForm}

--- a/server/src/database/schemas.ts
+++ b/server/src/database/schemas.ts
@@ -25,8 +25,8 @@ export default class Schemas {
       name: { type: String, required: true },
       quantity: { type: Number, required: true },
       unit: { type: String, required: true },
-      price: { type: Number, required: false },
-      market: { type: String, required: false },
+      price: { type: Number, required: true, default: 0 },
+      market: { type: String, required: true, default: "" },
       checked: { type: Boolean, default: true },
     });
   }

--- a/server/src/database/schemas.ts
+++ b/server/src/database/schemas.ts
@@ -3,32 +3,38 @@ import IList from "../interfaces/list";
 import IUser from "../interfaces/user";
 import IMessage from "../interfaces/message";
 import INotification, { NotificationTypes } from "../interfaces/notification";
+import IProduct from "../interfaces/product";
 
 export default class Schemas {
+  private _productSchema: mongoose.Schema<IProduct>;
   private _listSchema: mongoose.Schema<IList>;
   private _userSchema: mongoose.Schema<IUser>;
   private _messageSchema: mongoose.Schema<IMessage>;
   private _notificationSchema: mongoose.Schema<INotification>;
 
   constructor() {
+    this._productSchema = this.setProductSchema();
     this._listSchema = this.setListSchema();
     this._userSchema = this.setUserSchema();
     this._messageSchema = this.setMessageSchema();
     this._notificationSchema = this.setNotificationSchema();
   }
 
+  private setProductSchema(): mongoose.Schema<IProduct> {
+    return new mongoose.Schema<IProduct>({
+      name: { type: String, required: true },
+      quantity: { type: Number, required: true },
+      unit: { type: String, required: true },
+      price: { type: Number, required: false },
+      market: { type: String, required: false },
+      checked: { type: Boolean, default: true },
+    });
+  }
+
   private setListSchema(): mongoose.Schema<IList> {
     return new mongoose.Schema<IList>({
       listName: { type: String, required: true },
-      products: [
-        {
-          name: { type: String, required: true },
-          quantity: { type: Number, required: true },
-          unit: { type: String, required: true },
-          price: { type: Number, required: true },
-          checked: { type: Boolean, default: true },
-        },
-      ],
+      products: [this._productSchema],
       owner: { type: Schema.Types.ObjectId, required: true },
       members: [{ userId: { type: Schema.Types.ObjectId } }],
       createdAt: { type: Date, default: Date.now() },
@@ -72,6 +78,10 @@ export default class Schemas {
       createdAt: { type: Date, default: Date.now() },
       updatedAt: { type: Date, default: Date.now() },
     });
+  }
+
+  public get productSchema() {
+    return this._productSchema;
   }
 
   public get listSchema() {

--- a/server/src/interfaces/product.ts
+++ b/server/src/interfaces/product.ts
@@ -5,7 +5,7 @@ export default interface IProduct {
   name: string;
   quantity: Number;
   unit: string;
-  price?: Number;
-  market?: String;
+  price: Number;
+  market: String;
   checked?: Boolean;
 }

--- a/server/src/interfaces/product.ts
+++ b/server/src/interfaces/product.ts
@@ -1,11 +1,11 @@
 import { Schema } from "mongoose";
 
 export default interface IProduct {
+  _id?: Schema.Types.ObjectId | string;
   name: string;
   quantity: Number;
   unit: string;
   price?: Number;
   market?: String;
   checked?: Boolean;
-  _id?: Schema.Types.ObjectId | string;
 }

--- a/server/src/interfaces/product.ts
+++ b/server/src/interfaces/product.ts
@@ -6,6 +6,6 @@ export default interface IProduct {
   quantity: Number;
   unit: string;
   price: Number;
-  market: String;
+  market?: String;
   checked?: Boolean;
 }

--- a/server/src/interfaces/product.ts
+++ b/server/src/interfaces/product.ts
@@ -4,7 +4,8 @@ export default interface IProduct {
   name: string;
   quantity: Number;
   unit: string;
-  price: Number;
+  price?: Number;
+  market?: String;
   checked?: Boolean;
   _id?: Schema.Types.ObjectId | string;
 }

--- a/server/src/validators/validate.ts
+++ b/server/src/validators/validate.ts
@@ -66,7 +66,6 @@ const allFieldsToValidate: {
     { title: "quantity", type: "integer" },
     { title: "unit", type: "measureunit" },
     { title: "price", type: "float" },
-    { title: "checked", type: "boolean" },
   ],
 };
 

--- a/server/src/validators/validate.ts
+++ b/server/src/validators/validate.ts
@@ -40,6 +40,7 @@ const allFieldsToValidate: {
     { title: "quantity", type: "integer" },
     { title: "unit", type: "measureunit" },
     { title: "price", type: "float" },
+    { title: "market", type: "optional-name" },
     { title: "checked", type: "boolean" },
   ],
   patchMembers: [
@@ -66,6 +67,7 @@ const allFieldsToValidate: {
     { title: "quantity", type: "integer" },
     { title: "unit", type: "measureunit" },
     { title: "price", type: "float" },
+    { title: "market", type: "optional-name" },
   ],
 };
 
@@ -194,6 +196,18 @@ function getAllValidations(
           .isBoolean()
           .withMessage(`${fieldTitle} must be a boolean value.`)
           .toBoolean();
+
+      case "optional-name":
+        return check(fieldTitle)
+          .trim()
+          .escape()
+          .isString()
+          .isLength({ max: 50 })
+          .withMessage(`${fieldTitle} must have less than 50 characters.`)
+          .matches(/^[a-zA-Zà-úÀ-Ú0-9 ]*$/)
+          .withMessage(`${fieldTitle} must contain only letters and digits.`)
+          .isString()
+          .withMessage(`${fieldTitle} must be a string.`);
 
       default:
         return check(fieldTitle).trim().notEmpty();


### PR DESCRIPTION
This PR has 2 main changes:
- the price field on product edits is now optional, so users can add a product without specifying its price;
- there's a new fielt: market - this will be later turned into the requested product market feature;

The automated tests have to be updated at a later date.