### PR TITLE
tests: create simple examples websocket tests

### DIFF
--- a/__tests__/helpers/createWebsocketServer.ts
+++ b/__tests__/helpers/createWebsocketServer.ts
@@ -21,6 +21,12 @@ function createWebSocketServer(server: http.Server) {
           for (let i = 1; i <= 3; i++) {
             webSocket.send(data.value);
           }
+          break;
+        }
+        //server send a message to all connected clients
+        case "ECHO_TO_ALL": {
+          myIo.emit("message", data.value);
+          break;
         }
       }
     });

--- a/__tests__/helpers/createWebsocketServer.ts
+++ b/__tests__/helpers/createWebsocketServer.ts
@@ -1,7 +1,8 @@
 // createWebSocketServer.js
 import http, { createServer } from "http";
-
 import { Server, Socket as SocketServer } from "socket.io";
+
+const groupNames: string[] = [];
 
 function createWebSocketServer(server: http.Server) {
   let myIo: Server;
@@ -12,20 +13,50 @@ function createWebSocketServer(server: http.Server) {
     webSocket.on("message", function (message) {
       const data = JSON.parse(message);
       switch (data.type) {
-        case "ECHO": {
+        case "ECHO":
           webSocket.send(data.value);
           break;
-        }
-        // causes the server to send multiple responses to the same client
-        case "ECHO_TIMES_3": {
+        case "ECHO_TIMES_3":
           for (let i = 1; i <= 3; i++) {
             webSocket.send(data.value);
           }
           break;
-        }
-        //server send a message to all connected clients
-        case "ECHO_TO_ALL": {
+        case "ECHO_TO_ALL":
           myIo.emit("message", data.value);
+          break;
+        case "CREATE_GROUP": {
+          const groupName = data.value;
+          if (!groupNames.includes(groupName)) {
+            groupNames.push(groupName);
+            webSocket.join(groupName);
+            webSocket.send(groupName);
+          } else {
+            webSocket.send("GROUP_UNAVAILABLE");
+          }
+          break;
+        }
+        case "JOIN_GROUP": {
+          const joinGroupName = data.value;
+          const currentGroup = groupNames.find((group) =>
+            webSocket.rooms.has(group)
+          );
+          if (!currentGroup) {
+            webSocket.send("GROUP_UNAVAILABLE");
+          } else {
+            webSocket.leave(currentGroup);
+            webSocket.join(joinGroupName);
+            webSocket.send(joinGroupName);
+          }
+          break;
+        }
+        case "MESSAGE_GROUP": {
+          const { groupMessage } = data.value;
+          const currentGroup = groupNames.find((group) =>
+            webSocket.rooms.has(group)
+          );
+          if (currentGroup) {
+            myIo.to(currentGroup).emit("message", groupMessage);
+          }
           break;
         }
       }

--- a/__tests__/helpers/createWebsocketServer.ts
+++ b/__tests__/helpers/createWebsocketServer.ts
@@ -1,0 +1,17 @@
+// createWebSocketServer.js
+import { createServer } from "http";
+
+import { Server, Socket as SocketServer } from "socket.io";
+
+function createWebSocketServer(server: any) {
+  let myIo: Server;
+
+  myIo = new Server(server);
+
+  myIo.on("connection", function (webSocket) {
+    webSocket.on("message", function (message) {
+      webSocket.send(message);
+    });
+  });
+}
+export default createWebSocketServer;

--- a/__tests__/helpers/createWebsocketServer.ts
+++ b/__tests__/helpers/createWebsocketServer.ts
@@ -1,16 +1,28 @@
 // createWebSocketServer.js
-import { createServer } from "http";
+import http, { createServer } from "http";
 
 import { Server, Socket as SocketServer } from "socket.io";
 
-function createWebSocketServer(server: any) {
+function createWebSocketServer(server: http.Server) {
   let myIo: Server;
 
   myIo = new Server(server);
 
-  myIo.on("connection", function (webSocket) {
+  myIo.on("connection", function (webSocket: SocketServer) {
     webSocket.on("message", function (message) {
-      webSocket.send(message);
+      const data = JSON.parse(message);
+      switch (data.type) {
+        case "ECHO": {
+          webSocket.send(data.value);
+          break;
+        }
+        // causes the server to send multiple responses to the same client
+        case "ECHO_TIMES_3": {
+          for (let i = 1; i <= 3; i++) {
+            webSocket.send(data.value);
+          }
+        }
+      }
     });
   });
 }

--- a/__tests__/helpers/webSocketTestUtils.ts
+++ b/__tests__/helpers/webSocketTestUtils.ts
@@ -31,7 +31,7 @@ function waitForSocketState(socket: SocketClient, waitIsConnected: boolean) {
 // essa função permite retornar o client e todas as mensagens recebidas
 async function createSocketClient(
   port: number,
-  closeAfter: number
+  closeAfter?: number
 ): Promise<[SocketClient, string[]]> {
   const clientSocket: SocketClient = Client(`http://localhost:${port}`);
 
@@ -41,8 +41,10 @@ async function createSocketClient(
 
   clientSocket.on("message", (data: string) => {
     messages.push(data);
+    console.log("OLHA MESSAGES->", messages, data);
     // troquei de === por >= com medo de algum loop infinito
-    if (messages.length >= closeAfter) {
+    if (messages.length === closeAfter) {
+      console.log("Fechou alguem!", data);
       clientSocket.close();
     }
   });

--- a/__tests__/helpers/webSocketTestUtils.ts
+++ b/__tests__/helpers/webSocketTestUtils.ts
@@ -1,0 +1,52 @@
+// webSocketTestUtils.js
+import http from "http";
+import createWebSocketServer from "./createWebsocketServer";
+import Client, { Socket as SocketClient, io } from "socket.io-client";
+
+function startServer(port: number) {
+  const server = http.createServer();
+  createWebSocketServer(server);
+  return new Promise((resolve) => {
+    server.listen(port, () => resolve(server));
+  });
+}
+
+// Se o usuário está esperando a conexão está aberta, waitIsConnected vai ser true
+// e a comparação continua até que socket.connected seja true também
+// sea função foi passada esperando que a conexão seja fechada, é passado waitIsConnected=false
+// e a comparação continua até que socket.connected seja falso também
+//
+function waitForSocketState(socket: SocketClient, waitIsConnected: boolean) {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
+      if (socket.connected === waitIsConnected) {
+        resolve("Socket state is now as expected."); // i added a message because TS
+      } else {
+        waitForSocketState(socket, waitIsConnected).then(resolve);
+      }
+    }, 5);
+  });
+}
+
+// essa função permite retornar o client e todas as mensagens recebidas
+async function createSocketClient(
+  port: number,
+  closeAfter: number
+): Promise<[SocketClient, string[]]> {
+  const clientSocket: SocketClient = Client(`http://localhost:${port}`);
+
+  await waitForSocketState(clientSocket, true);
+
+  const messages: string[] = [];
+
+  clientSocket.on("message", (data: string) => {
+    messages.push(data);
+    // troquei de === por >= com medo de algum loop infinito
+    if (messages.length >= closeAfter) {
+      clientSocket.close();
+    }
+  });
+  return [clientSocket, messages];
+}
+
+export { startServer, waitForSocketState, createSocketClient };

--- a/__tests__/websocket/example.test.ts
+++ b/__tests__/websocket/example.test.ts
@@ -50,3 +50,25 @@ describe("my awesome project", () => {
     });
   });
 });
+
+/*
+
+// createWebSocketServer.test.js
+
+// https://thomason-isaiah.medium.com/writing-integration-tests-for-websocket-servers-using-jest-and-ws-8e5c61726b2a
+
+describe("WebSocket Server", () => {
+  beforeAll(() => {
+    // Start server
+  });
+  afterAll(() => {
+    // Close server
+  });
+  test("Server echoes the message it receives from client", () => {
+    // 1. Create test client
+    // 2. Send client message
+    // 3. Close the client after it receives the response
+    // 4. Perform assertions on the response
+  });
+});
+*/

--- a/__tests__/websocket/example.test.ts
+++ b/__tests__/websocket/example.test.ts
@@ -1,0 +1,52 @@
+import { createServer } from "http";
+import { Server, Socket as SocketServer } from "socket.io";
+//import { Socket, io } from "socket.io-client";
+import Client, { Socket as SocketClient, io } from "socket.io-client";
+
+import Websocket from "../../server/src/websocket";
+
+describe("my awesome project", () => {
+  let myIo: Server, serverSocket: SocketServer, clientSocket: SocketClient;
+
+  beforeAll((done) => {
+    const httpServer = createServer();
+    //io = new Server(httpServer);
+    myIo = new Server(httpServer);
+    httpServer.listen(() => {
+      const address = httpServer.address();
+      if (address && typeof address === "object" && "port" in address) {
+        const port = address.port;
+        clientSocket = Client(`http://localhost:${port}`) as SocketClient;
+        myIo.on("connection", (socket: SocketServer) => {
+          serverSocket = socket;
+        });
+        clientSocket.on("connect", done);
+      } else {
+        done.fail("Unable to determine server port");
+      }
+    });
+  });
+
+  afterAll(() => {
+    myIo.close();
+    clientSocket.close();
+  });
+
+  test("should work", (done) => {
+    clientSocket.on("hello", (arg: string) => {
+      expect(arg).toBe("world");
+      done();
+    });
+    serverSocket.emit("hello", "world");
+  });
+
+  test("should work (with ack)", (done) => {
+    serverSocket.on("hi", (cb: (arg: string) => void) => {
+      cb("hola");
+    });
+    clientSocket.emit("hi", (arg: string) => {
+      expect(arg).toBe("hola");
+      done();
+    });
+  });
+});

--- a/__tests__/websocket/exampleArticle.test.ts
+++ b/__tests__/websocket/exampleArticle.test.ts
@@ -1,0 +1,43 @@
+import http from "http";
+import {
+  startServer,
+  waitForSocketState,
+  createSocketClient,
+} from "../helpers/webSocketTestUtils";
+import Client, { Socket as SocketClient, io } from "socket.io-client";
+
+const port = 3001;
+
+describe("WebSocket Server", () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    // Start server
+    server = (await startServer(port)) as http.Server;
+  });
+
+  afterAll(() => {
+    // Close server
+    server.close();
+  });
+
+  test("Server echoes the message it receives from client", async () => {
+    // 1. Create test client
+    //const clientSocket: SocketClient = Client(`http://localhost:${port}`);
+    //await waitForSocketState(clientSocket, true);
+
+    const [clientSocket, messages] = await createSocketClient(port, 1);
+
+    const testMessage = "This is a test message";
+
+    // 2. Send client message
+    clientSocket.send(testMessage);
+
+    // 4. Perform assertions on the response
+    await waitForSocketState(clientSocket, false);
+    //como passei (port,1), então só uma mensagem foi enviada e só quero receber
+    // uma string
+    const [responseMessage] = messages;
+    expect(responseMessage).toBe(testMessage);
+  });
+});

--- a/__tests__/websocket/exampleArticle.test.ts
+++ b/__tests__/websocket/exampleArticle.test.ts
@@ -60,4 +60,26 @@ describe("WebSocket Server", () => {
     expect(messages).toStrictEqual(expectedMessages);
     expect(messages.length).toBe(3);
   });
+
+  // ...
+  test("When given an ECHO_TO_ALL message, the server sends the message it receives to all clients", async () => {
+    // Create test clients
+    const [client1, messages1] = await createSocketClient(port, 1);
+    const [client2, messages2] = await createSocketClient(port, 1);
+    const [client3, messages3] = await createSocketClient(port, 1);
+    const testMessage = {
+      type: "ECHO_TO_ALL",
+      value: "This is a test message sent to all clients",
+    };
+    // Send client message - basta um client mandar uma mensagem, esse teste
+    // verifica se o server emite a mensagem para todos os clients
+    client1.send(JSON.stringify(testMessage));
+    // Perform assertions on the responses
+    await waitForSocketState(client1, false);
+    await waitForSocketState(client2, false);
+    await waitForSocketState(client3, false);
+    expect(messages1[0]).toBe(testMessage.value);
+    expect(messages2[0]).toBe(testMessage.value);
+    expect(messages3[0]).toBe(testMessage.value);
+  });
 });

--- a/__tests__/websocket/exampleArticle.test.ts
+++ b/__tests__/websocket/exampleArticle.test.ts
@@ -23,21 +23,41 @@ describe("WebSocket Server", () => {
 
   test("Server echoes the message it receives from client", async () => {
     // 1. Create test client
-    //const clientSocket: SocketClient = Client(`http://localhost:${port}`);
-    //await waitForSocketState(clientSocket, true);
-
     const [clientSocket, messages] = await createSocketClient(port, 1);
 
-    const testMessage = "This is a test message";
+    const testMessage = { type: "ECHO", value: "This is a test message" };
 
     // 2. Send client message
-    clientSocket.send(testMessage);
+    clientSocket.send(JSON.stringify(testMessage));
 
     // 4. Perform assertions on the response
+    //como quero esperar o socket está fechado, para iniciar os testes, passo FALSE
+    // pois assim ele vai esperar até que disconnect(connect===false)
     await waitForSocketState(clientSocket, false);
     //como passei (port,1), então só uma mensagem foi enviada e só quero receber
     // uma string
     const [responseMessage] = messages;
-    expect(responseMessage).toBe(testMessage);
+    expect(responseMessage).toBe(testMessage.value);
+  });
+
+  //
+  test("When given an ECHO_TIMES_3 message, the server echoes the message it receives from client 3 times", async () => {
+    // Create test client
+    const [client, messages] = await createSocketClient(port, 3);
+    const testMessage = {
+      type: "ECHO_TIMES_3",
+      value: "This is a test message send 3 times",
+    };
+    const expectedMessages: string[] = [...Array(3)].map(
+      () => testMessage.value
+    );
+
+    // Send client message
+    client.send(JSON.stringify(testMessage));
+    // Perform assertions on the response
+    await waitForSocketState(client, false);
+
+    expect(messages).toStrictEqual(expectedMessages);
+    expect(messages.length).toBe(3);
   });
 });

--- a/__tests__/websocket/exampleArticle.test.ts
+++ b/__tests__/websocket/exampleArticle.test.ts
@@ -82,4 +82,52 @@ describe("WebSocket Server", () => {
     expect(messages2[0]).toBe(testMessage.value);
     expect(messages3[0]).toBe(testMessage.value);
   });
+  /*
+  test("When given a MESSAGE_GROUP message, the server echoes the message it receives to everyone in the specified group", async () => {
+    // Create test clients
+    const [client1, messages1] = await createSocketClient(port); //no artigo ele nao botou o segundo parametro, coloquei 4 por enquanto
+    const [client2, messages2] = await createSocketClient(port, 2);
+    const [client3, messages3] = await createSocketClient(port); //no artigo ele nao botou o segundo parametro, coloquei 4 por enquanto
+    const creationMessage = { type: "CREATE_GROUP", value: "TEST_GROUP" };
+    const testMessage = "This is a test message sent to a group";
+
+    client2.on("close", () => {
+      console.log("ENTROU AQUI!");
+      client1.close();
+      client3.close();
+    });
+
+    // Setup test clients to send messages and close in the right order
+    client1.on("message", (data) => {
+      if (data === creationMessage.value) {
+        const joinMessage = { type: "JOIN_GROUP", value: data };
+        const groupMessage = {
+          type: "MESSAGE_GROUP",
+          value: { groupName: data, groupMessage: testMessage },
+        };
+        client2.send(JSON.stringify(joinMessage));
+        client2.send(JSON.stringify(groupMessage));
+      }
+    });
+
+    // Send client message
+    client1.send(JSON.stringify(creationMessage));
+    // Perform assertions on the responses
+    await waitForSocketState(client1, false);
+    await waitForSocketState(client2, false);
+    await waitForSocketState(client3, false);
+
+    const [group1, message1] = messages1;
+    const [group2, message2] = messages2;
+
+    // Both client1 and client2 should have joined the same group.
+    expect(group1).toBe(creationMessage.value);
+    expect(group2).toBe(creationMessage.value);
+    // Both client1 and client2 should have received the group message.
+    expect(message1).toBe(testMessage);
+    expect(message2).toBe(testMessage);
+    // client3 should have received no messages
+    expect(messages3.length).toBe(0);
+  });
+  */
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "ioredis": "^5.3.2",
                 "jsonwebtoken": "^9.0.1",
                 "mongoose": "^7.3.1",
-                "socket.io": "^4.7.1"
+                "socket.io": "^4.7.1",
+                "socket.io-client": "^4.7.2"
             },
             "devDependencies": {
                 "@types/bcrypt": "^5.0.0",
@@ -2510,6 +2511,47 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/engine.io-client": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+            "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.11.0",
+                "xmlhttprequest-ssl": "~2.0.0"
+            }
+        },
+        "node_modules/engine.io-client/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/engine.io-client/node_modules/engine.io-parser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+            "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/engine.io-client/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/engine.io-parser": {
             "version": "5.1.0",
@@ -5354,6 +5396,41 @@
                 "ws": "~8.11.0"
             }
         },
+        "node_modules/socket.io-client": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+            "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.2",
+                "engine.io-client": "~6.5.2",
+                "socket.io-parser": "~4.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-client/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/socket.io-client/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "node_modules/socket.io-parser": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -6220,6 +6297,14 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/xtend": {
@@ -8275,6 +8360,38 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
+        "engine.io-client": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+            "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+            "requires": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.11.0",
+                "xmlhttprequest-ssl": "~2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "engine.io-parser": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+                    "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ=="
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -10420,6 +10537,32 @@
                 "ws": "~8.11.0"
             }
         },
+        "socket.io-client": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+            "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+            "requires": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.2",
+                "engine.io-client": "~6.5.2",
+                "socket.io-parser": "~4.2.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
         "socket.io-parser": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -11006,6 +11149,11 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
             "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
             "requires": {}
+        },
+        "xmlhttprequest-ssl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.1",
         "mongoose": "^7.3.1",
-        "socket.io": "^4.7.1"
+        "socket.io": "^4.7.1",
+        "socket.io-client": "^4.7.2"
     },
     "devDependencies": {
         "@types/bcrypt": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build": "tsc && cd client && yarn --cwd ./ build",
         "dev": "nodemon -L ./server/server.ts",
         "test": "jest --runInBand --detectOpenHandles --verbose __tests__/",
-        "test:services": "jest __tests__/unit/services"
+        "test:services": "jest __tests__/unit/services",
+        "test:websocket": "jest --runInBand --detectOpenHandles --verbose __tests__/websocket"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR will:
- Add two similar examples about websocket from (https://socket.io/pt-br/docs/v4/testing/#example-with-jest);
- Add some similar examples about websocket from (https://thomason-isaiah.medium.com/writing-integration-tests-for-websocket-servers-using-jest-and-ws-8e5c61726b2a);
To run only websocket test you can use: 
npm run test:websocket
PS.: Last example from article has a error, so I comment last test from websocket/exampleArticle.test . Later I will explain the reason.
